### PR TITLE
This fixes a problem with hidden variables for array variables.

### DIFF
--- a/src/Message/Traits/RedirectHtmlTrait.php
+++ b/src/Message/Traits/RedirectHtmlTrait.php
@@ -114,8 +114,8 @@ trait RedirectHtmlTrait
         foreach ($this->getRedirectData() as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $iKey => $iValue) {
-                    $key = $key . '[' . $iKey . ']';
-                    $hiddenFields .= $this->generateHiddenInput($key, $iValue) . "\n";
+                    $nKey = $key . '[' . $iKey . ']';
+                    $hiddenFields .= $this->generateHiddenInput($nKey, $iValue) . "\n";
                 }
             } else {
                 $hiddenFields .= $this->generateHiddenInput($key, $value) . "\n";


### PR DESCRIPTION
In \ByTIC\Omnipay\Common\Message\Traits\RedirectHtmlTrait::generateHiddenInputs, when a value is an array, in the nested foreach loop, the name of the input variable is not properly reset.

Example:
```
$ExtraData['failedurl'] = 'failed';
$ExtraData['successurl'] = 'success';
```

Before:
ExtraData[failedurl]=failed&ExtraData[failedurl][successurl]=success

After:
ExtraData[failedurl]=failed&ExtraData[successurl]=success